### PR TITLE
Monospace each line separately

### DIFF
--- a/server.js
+++ b/server.js
@@ -107,7 +107,6 @@ const submitSearch = (file_path) => new Promise(async (resolve, reject) => {
   if (similarity < 0.92) {
     text = "I have low confidence in this, wild guess:\n";
   }
-  text += "```\n";
   text += [
     title,
     title_chinese,
@@ -120,11 +119,11 @@ const submitSearch = (file_path) => new Promise(async (resolve, reject) => {
     ],
     []
   )
+    .map((t) => `\`${t}\``)
     .join("\n");
   text += "\n";
-  text += `EP#${episode.toString().padStart(2, "0")} ${formatTime(at)}\n`;
-  text += `${(similarity * 100).toFixed(1)}% similarity\n`;
-  text += "```";
+  text += `\`EP#${episode.toString().padStart(2, "0")} ${formatTime(at)}\`\n`;
+  text += `\`${(similarity * 100).toFixed(1)}% similarity\`\n`;
   const videoLink = [
     `https://media.trace.moe/video/${anilist_id}/${encodeURIComponent(filename)}?`,
     `t=${at}&`,


### PR DESCRIPTION
Monospace each line of result message separately instead of monospacing the whole message for easier title copying on android. 
Android telegram client allows to copy monospaced text with one tap, so it'll be easier to just copy the required title instead of copying the whole message and then cutting the actual title from it