### PR TITLE
Added ability to search by static image URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The bot is live on telegram now https://telegram.me/WhatAnimeBot
 - Show anime titles in multiple languages
 - Telegram group support
 - Image, GIF, Video support
+- Support for URL to static image
 - Video preview
 
 ## How to use
@@ -31,7 +32,7 @@ _Note that the bot has no access to your messages before it is added to your gro
 
 ## Known issues
 - Stickers are not supported
-- Image URL is not supported
+- URL for gif or video is not supported
 - Sometimes video preview is missing
 
 ![Demo](demo.png)

--- a/server.js
+++ b/server.js
@@ -58,7 +58,7 @@ const submitSearch = (imageFileURL) =>
       return;
     }
     if (!searchResult.docs) {
-      resolve({ text: "Backend server error, please try again later." });
+      resolve({ text: "Error with search response. Is your query correctly formatted? Note: URL searches must be for static images, not gifs" });
       return;
     }
     if (searchResult.docs && searchResult.docs.length <= 0) {

--- a/server.js
+++ b/server.js
@@ -3,11 +3,6 @@ const TelegramBot = require("node-telegram-bot-api");
 const fetch = require("node-fetch");
 const redis = require("redis");
 const { promisify } = require("util");
-<<<<<<< HEAD
-=======
-const getUrls = require("get-urls");
-const { off } = require("process");
->>>>>>> 0b6f7ef... Implemented much simpler URL search
 
 const { SERVER_PORT, REDIS_HOST, TELEGRAM_TOKEN, TELEGRAM_WEBHOOK, TRACE_MOE_TOKEN } = process.env;
 
@@ -28,6 +23,9 @@ const bot = new TelegramBot(TELEGRAM_TOKEN, {
   webHook: { port: SERVER_PORT },
   polling: false,
 });
+
+const infoText =
+  "You can Send / Forward anime screenshots to me. Directly send images, gifs, videos, or URLs for staic images. No URLs for gifs or videos, please ;)";
 
 const formatTime = (timeInSeconds) => {
   const sec_num = parseInt(timeInSeconds, 10);
@@ -67,7 +65,7 @@ const submitSearch = (imageFileURL) =>
       return;
     }
     if (searchResult.docs && searchResult.docs.length <= 0) {
-      resolve({ text: "Sorry, I don't know what anime is it :\\" });
+      resolve({ text: "Sorry, I don't know what anime it is :\\" });
       return;
     }
     const {
@@ -198,20 +196,17 @@ const limitExceeded = async (message) => {
 const privateMessageHandler = async (message) => {
   const responding_msg = message.reply_to_message ? message.reply_to_message : message;
   if (!getImageFromMessage(responding_msg)) {
-    await bot.sendMessage(
-      message.chat.id,
-<<<<<<< HEAD
-      "You can Send / Forward anime screenshots to me. I can't get images from URLs, please send the image directly to me ;)"
-=======
-      infoText
->>>>>>> 0b6f7ef... Implemented much simpler URL search
-    );
+    await bot.sendMessage(message.chat.id, infoText);
     return;
   }
   if (await limitExceeded(message)) {
-    await bot.sendMessage(message.chat.id, "You exceeded the search limit, please try again later", {
-      reply_to_message_id: responding_msg.message_id,
-    });
+    await bot.sendMessage(
+      message.chat.id,
+      "You exceeded the search limit, please try again later",
+      {
+        reply_to_message_id: responding_msg.message_id,
+      }
+    );
     return;
   }
 
@@ -259,7 +254,6 @@ const privateMessageHandler = async (message) => {
   }
 };
 
-
 const groupMessageHandler = async (message) => {
   if (!messageIsMentioningBot(message)) {
     return;
@@ -276,13 +270,13 @@ const groupMessageHandler = async (message) => {
   }
 
   if (await limitExceeded(message)) {
-<<<<<<< HEAD
-    await bot.sendMessage(message.chat.id, "Your search limit exceeded, please try again later", {
-=======
-    await bot.sendMessage(message.chat.id, "You exceeded the search limit, please try again later", {
->>>>>>> 0b6f7ef... Implemented much simpler URL search
-      reply_to_message_id: responding_msg.message_id,
-    });
+    await bot.sendMessage(
+      message.chat.id,
+      "You exceeded the search limit, please try again later",
+      {
+        reply_to_message_id: responding_msg.message_id,
+      }
+    );
     return;
   }
 


### PR DESCRIPTION
I added in the ability to send the bot a URL to a static image and have it return results from trace.moe using the URL parameter in the official API. The bot will parse a URL out of any message, but will only send the first URL it finds to the trace.moe API. If both an image file and URL are sent in the same message, it will prioritize the image file.
I wanted to do as little refactoring as possible, so there may be some duplicate code that can be turned into functions, if desired.

Tests I did:
- Send file to bot through private and group message (to make sure it still worked)
- Send URL to bot through PM and through group message with @ mention
- Forward image to bot through PM
- Forward URL to bot through PM
- Forward image or URL to group message with @ mention in the message already

I tested using polling instead of webhooks (because I'm not really sure how webhooks work yet haha), but I don't think this should affect the functionality. I also tested without an API token from trace.moe, but it seemed to work fine without one. I left the code in for injecting the token into the URL request, still.

I also updated the bot messages and such to reflect the changes :D