### PR TITLE
fix: spoiler video is not mark as spoiler in group

### DIFF
--- a/server.js
+++ b/server.js
@@ -368,24 +368,13 @@ const groupMessageHandler = async (message) => {
 
   const result = await submitSearch(imageURL, responding_msg, message);
 
-  if (result.isAdult) {
-    await sendMessage(
-      message.chat.id,
-      "I've found an adult result 😳\nPlease forward it to me via Private Chat 😏",
-      {
-        reply_to_message_id: responding_msg.message_id,
-      }
-    );
-    return;
-  }
-
   if (result.video && !messageIsSkipPreview(message)) {
     const videoLink = messageIsMute(message) ? `${result.video}&mute` : result.video;
     const video = await fetch(videoLink, { method: "HEAD" });
     if (video.ok && video.headers.get("content-length") > 0) {
       await sendVideo(message.chat.id, videoLink, {
         caption: result.text,
-        has_spoiler: responding_msg.has_media_spoiler,
+        has_spoiler: result.isAdult || responding_msg.has_media_spoiler,
         parse_mode: "Markdown",
         reply_to_message_id: responding_msg.message_id,
       });


### PR DESCRIPTION
Sending video with spoiler for the first time (no cache) through Telegram Bot API server using URL will not mark as spoiler.

Uploading file locally instead of passing URL to Telegram Bot API server to fix this issue.

bug tracker: https://bugs.telegram.org/c/23674

**This commit will increase bot bandwidth usage.**

This reverts commit https://github.com/soruly/trace.moe-telegram-bot/commit/375c4ba2b2ff9bbd6a60002a73993f30c76a72bb.